### PR TITLE
"K"-Prefix bei customerId entfernt

### DIFF
--- a/dashboard_api_v1.md
+++ b/dashboard_api_v1.md
@@ -25,7 +25,7 @@ Die Benutzerdaten hierfür sind die selben, die für den Login auf [https://dash
     {
         "username" : "myUser",
         "password" : "mySuperSecretPwd",
-        "customerId" : "K123456"
+        "customerId" : "123456"
     }
 
 Nach einem erfolgreichen Login erhält man die Session ID:


### PR DESCRIPTION
Authentifizierung funktioniert nur ohne "K" vor der Kundennummer